### PR TITLE
FPN Net Type, Net Type changing, manual Transition activation

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -20,11 +20,13 @@ module pl.edu.ur.pnes {
     exports pl.edu.ur.pnes.ui.panels;
     exports pl.edu.ur.pnes.ui.controls;
     exports pl.edu.ur.pnes.petriNet;
+    exports pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
     exports pl.edu.ur.pnes.petriNet.simulator;
     exports pl.edu.ur.pnes.petriNet.events;
     exports pl.edu.ur.pnes.ui.utils;
     opens pl.edu.ur.pnes.ui.utils to javafx.fxml;
     opens pl.edu.ur.pnes.editor to javafx.fxml;
+    exports pl.edu.ur.pnes.petriNet.netTypes;
 
 //    exports com.sun.javafx.logging;
 }

--- a/src/main/java/pl/edu/ur/pnes/MainApp.java
+++ b/src/main/java/pl/edu/ur/pnes/MainApp.java
@@ -2,18 +2,18 @@ package pl.edu.ur.pnes;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Point3D;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import jfxtras.styles.jmetro.JMetro;
 import jfxtras.styles.jmetro.Style;
 import pl.edu.ur.pnes.editor.Session;
-import pl.edu.ur.pnes.petriNet.Arc;
-import pl.edu.ur.pnes.petriNet.PetriNet;
-import pl.edu.ur.pnes.petriNet.Place;
-import pl.edu.ur.pnes.petriNet.Transition;
+import pl.edu.ur.pnes.petriNet.*;
+import pl.edu.ur.pnes.petriNet.netTypes.NetType;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Random;
 
 public class MainApp extends Application {
     public static Stage mainStage;
@@ -41,16 +41,19 @@ public class MainApp extends Application {
 
         // Initial for testing
         final var net = new PetriNet();
+        net.setNetType(NetType.PN);
         {
             final Place place1 = new Place(net);
             final Place place2 = new Place(net);
             final Place place3 = new Place(net);
             final Place place4 = new Place(net);
-            place1.setTokens(2);
+//            place1.setTokensAs(Double.class, 2d);
+            place1.setTokensAs(Integer.class, 2);
             final Transition transition1 = new Transition(net);
             final Transition transition2 = new Transition(net);
             final Transition transition3 = new Transition(net);
-            place3.setTokens(1);
+//            place3.setTokensAs(Double.class, 1d);
+            place3.setTokensAs(Integer.class, 1);
             final Arc arc1 = new Arc(net, place1, transition1);
             final Arc arc2 = new Arc(net, transition1, place2);
             final Arc arc3 = new Arc(net, place2, transition2);
@@ -62,6 +65,9 @@ public class MainApp extends Application {
             final Arc arc7 = new Arc(net, transition3, place4);
             final Arc arc8 = new Arc(net, place3, transition2);
             net.addElements(place1, place2, place3, place4, transition1, transition2, transition3, arc1, arc2, arc3, arc4, arc5, arc6, arc7, arc8);
+            // place elements randomly
+            Random r = new Random();
+            net.getAllNodesStream().forEach(n -> n.setPosition(new Point3D(r.nextDouble(-5, 5), r.nextDouble(-5, 5), 0)));
         }
         mainController.open(new Session(net));
     }

--- a/src/main/java/pl/edu/ur/pnes/MainController.java
+++ b/src/main/java/pl/edu/ur/pnes/MainController.java
@@ -2,6 +2,8 @@ package pl.edu.ur.pnes;
 
 import com.panemu.tiwulfx.control.dock.DetachableTabPane;
 import com.panemu.tiwulfx.control.dock.TabStageFactory;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.fxml.FXML;
@@ -45,6 +47,7 @@ public class MainController implements Initializable {
             return false;
         }
         sessions.add(session);
+        setFocusedSession(session);
 
         final var panel = CenterPanelController.prepare(session);
         final var tab = centerTabPane.addTab(session.getName(), panel.getRoot());
@@ -53,9 +56,27 @@ public class MainController implements Initializable {
         return true;
     }
 
+
+    private final ObjectProperty<Session> focusedSession = new SimpleObjectProperty<>(null){
+        @Override
+        public void set(Session newValue) {
+            // TODO: here you can add code that runs when focused session changes
+            // e.g.
+            // this.focusTab(nevValue);
+            super.set(newValue);
+        }
+    };
+
     public Session getFocusedSession() {
-        // TODO: implement it properly once multiple sessions are here
-        return sessions.stream().findFirst().orElseThrow();
+        return focusedSession.get();
+    }
+
+    public ObjectProperty<Session> focusedSessionProperty() {
+        return focusedSession;
+    }
+
+    public void setFocusedSession(Session focusedSession) {
+        this.focusedSession.set(focusedSession);
     }
 
     public ProjectTreePanelController projectTreePanelController;

--- a/src/main/java/pl/edu/ur/pnes/editor/Session.java
+++ b/src/main/java/pl/edu/ur/pnes/editor/Session.java
@@ -85,7 +85,7 @@ public class Session {
             fileProperty().addListener(observable -> binding.invalidate());
             modifiedProperty().addListener(observable -> binding.invalidate());
             return new SimpleStringProperty() {{
-               bind(binding);
+                bind(binding);
             }};
         }
         return name;
@@ -94,7 +94,7 @@ public class Session {
     ////////////////////////////////////////////////////////////////////////////////
 
     public Session() {
-        this.net = new PetriNet();
+        this(new PetriNet());
     }
 
     public Session(PetriNet net) {

--- a/src/main/java/pl/edu/ur/pnes/petriNet/NetElement.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/NetElement.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 public abstract class NetElement {
     private final Logger logger = LogManager.getLogger(NetElement.class);
     public final StringProperty label = new SimpleStringProperty();
-    private final Net net;
+    protected final Net net;
     private final String id;
     private final StringProperty name = new SimpleStringProperty() {
         @Override

--- a/src/main/java/pl/edu/ur/pnes/petriNet/NetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/NetGroup.java
@@ -1,0 +1,27 @@
+package pl.edu.ur.pnes.petriNet;
+
+import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetGroup;
+
+/**
+ * Grous multiple {@link pl.edu.ur.pnes.petriNet.netTypes.NetType}s
+ * Allow for conditional enabling/disabling of fields when used with {@link UsedInNetGroup} and {@link pl.edu.ur.pnes.petriNet.netTypes.annotations.NotInNetGroup}
+ *
+ * @see pl.edu.ur.pnes.petriNet.netTypes.NetType
+ * @see pl.edu.ur.pnes.petriNet.netTypes.annotations.NotInNetGroup
+ * @see UsedInNetGroup
+ */
+public enum NetGroup {
+    NONE("NONE"),
+    CLASSICAL("Classical"),
+    NON_CLASSICAL("Non-classical");
+
+    public String getName() {
+        return name;
+    }
+
+    String name;
+
+    NetGroup(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/Place.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/Place.java
@@ -1,9 +1,13 @@
 package pl.edu.ur.pnes.petriNet;
 
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import pl.edu.ur.pnes.petriNet.events.NetEvent;
+import pl.edu.ur.pnes.petriNet.events.NetTypeChangedEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +15,7 @@ import java.util.Objects;
 
 public class Place extends Node {
     private static int placeCounter = 0;
-    private final DoubleProperty tokens = new SimpleDoubleProperty(0);
+    private final ObjectProperty<Object> tokens = new SimpleObjectProperty<>(0);
     private final DoubleProperty capacity = new SimpleDoubleProperty(Double.MAX_VALUE);
 
     /**
@@ -32,10 +36,17 @@ public class Place extends Node {
         do {
             placeCounter++;
             newId = "p" + placeCounter;
+            // increment ids until free one is found
         }
-        // increment ids until free one is found
         while (net.isNameUsed(newId));
+
+
         this.setName(newId);
+
+        net.addEventHandler(NetEvent.TYPE_CHANGED, this::netTypeChanged);
+
+        // invoke once to set initial values
+        this.netTypeChanged(new NetTypeChangedEvent(net.getNetType(), net.getNetType().netGroup));
     }
 
 
@@ -44,16 +55,123 @@ public class Place extends Node {
         return FXCollections.observableArrayList("place");
     }
 
-    public double getTokens() {
-        return tokens.get();
+    /**
+     * Determines if given tokens type can be used in current net type
+     *
+     * @param type tokens type to check
+     * @return true if given tokens type can be used, else false
+     * @see pl.edu.ur.pnes.petriNet.netTypes.NetType
+     * @see #tokensProperty()
+     */
+    public boolean canUseTokensAs(Class<?> type) {
+        return net.getNetType().tokensType.equals(type);
     }
 
-    public DoubleProperty tokensProperty() {
-        return tokens;
+    /**
+     * Reads tokensProperty as specified type. Throws if type is incompatible with current net type
+     *
+     * @param type Attempt will be made to read tokens in this type
+     * @param <T>  tokens type
+     * @return tokens as T type if they can be accessed
+     * @throws IllegalStateException if tokens cannot be accessed as given type
+     */
+    public <T> T getTokensAs(Class<T> type) throws IllegalStateException {
+        if (!canUseTokensAs(type))
+            throw new IllegalStateException("Cannot access tokens as " + type.getSimpleName() + " in net type " + this.net.getNetType());
+
+        //noinspection unchecked
+        return (T) this.tokens.get();
     }
 
-    public void setTokens(double tokens) {
-        this.tokens.set(tokens);
+    /**
+     * Returns tokens as an underlying object
+     *
+     * @return uncast tokens value
+     */
+    public Object getTokens() {
+        return this.tokens.get();
+    }
+
+    /**
+     * Gets string representation of tokens value
+     *
+     * @return string representing current tokens value
+     */
+    public String getTokensAsString() {
+        return this.tokens.getValue().toString();
+    }
+
+    /**
+     * Tries to set tokens used specified type
+     *
+     * @param type  Attempt will be made to set tokens in this type
+     * @param value New value for tokens to be set to
+     * @param <T>   type of tokens
+     * @throws IllegalStateException if tokens cannot be set as given type in current net type
+     */
+    public <T> void setTokensAs(Class<T> type, T value) throws IllegalStateException {
+        if (!canUseTokensAs(type))
+            throw new IllegalStateException("Cannot set tokens as " + type.getSimpleName() + " in net type " + this.net.getNetType());
+
+        this.tokens.set(value);
+    }
+
+    /**
+     * Set tokens object
+     * Warning! it does not check if set type is correct!
+     *
+     * @param value raw new value for tokens
+     */
+    public void setTokens(Object value) {
+        this.tokens.set(value);
+    }
+
+
+    /**
+     * Gets tokensProperty as a cast to specified type property. Throws if type is incompatible with current net type
+     *
+     * @param type Attempt will be made to read tokensProperty in this type
+     * @param <T>  tokens type
+     * @return tokens as T type if they can be accessed
+     * @throws IllegalStateException if tokens cannot be accessed as given type
+     */
+    public <T> ObjectProperty<T> tokensPropertyAs(Class<T> type) {
+        if (!canUseTokensAs(type))
+            throw new IllegalStateException("Cannot access tokens property as " + type.getSimpleName() + " in net type " + this.net.getNetType());
+
+        //noinspection unchecked
+        return (ObjectProperty<T>) this.tokens;
+    }
+
+    /**
+     * Gets raw tokens property
+     *
+     * @return raw tokens property
+     */
+    public ObjectProperty<Object> tokensProperty() {
+        return this.tokens;
+    }
+
+    /**
+     * Handles net type changing
+     */
+    private void netTypeChanged(NetTypeChangedEvent event) {
+        switch (event.getNewType()) {
+            case PN -> {
+                try {
+                    this.setTokensAs(Integer.class, (Integer) this.getTokens());
+                } catch (ClassCastException __) {
+                    this.setTokensAs(Integer.class, 0);
+                }
+            }
+            case FPN -> {
+                try {
+                    this.setTokensAs(Double.class, (Double) this.getTokens());
+                } catch (ClassCastException __) {
+                    this.setTokensAs(Double.class, 0d);
+                }
+            }
+        }
     }
 
     public double getCapacity() {

--- a/src/main/java/pl/edu/ur/pnes/petriNet/Transition.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/Transition.java
@@ -2,10 +2,17 @@ package pl.edu.ur.pnes.petriNet;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import pl.edu.ur.pnes.petriNet.netTypes.NetType;
+import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetType;
+import pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.Aggregation;
+import pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.SNorm;
+import pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.TNorm;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.IntBinaryOperator;
 
 public class Transition extends Node {
     private static int transitionCounter = 0;
@@ -48,6 +55,109 @@ public class Transition extends Node {
         while (net.isNameUsed(newId));
         this.setName(newId);
         classesList.add("transition");
+    }
+
+    /**
+     * Get input value based on input places aggregeted using {@link #inputAggregation}
+     *
+     * @return calculated input value
+     */
+    @UsedInNetType(NetType.FPN)
+    public double getFuzzyInputValue() {
+        // get correct identity
+        var identityElement = this.inputAggregation.getClass().isAssignableFrom(SNorm.class) ? SNorm.IDENTITY_ELEMENT : TNorm.IDENTITY_ELEMENT;
+        // aggregate with Transition aggregation
+        return this.inputs
+                .entrySet().stream()
+                .mapToDouble(placeArcEntry -> placeArcEntry.getKey().getTokensAs(Double.class) * placeArcEntry.getValue().getWeight()) // get all weights and multiply by arc weights
+                .reduce(identityElement, this.inputAggregation);
+    }
+
+    /**
+     * Get output value calculated by using {@link #internalTNorm} on input value and {@link #beta} coefficient
+     *
+     * @return Calculated output value
+     */
+    @UsedInNetType(NetType.FPN)
+    public double getFuzzyOutputValue() {
+        var inputValue = this.getFuzzyInputValue();
+        return this.internalTNorm.applyAsDouble(inputValue, this.beta);
+    }
+
+
+    /**
+     * Truth degree (beta) coefficient
+     */
+    @UsedInNetType(NetType.FPN)
+    public Double beta = 1d;
+
+    /**
+     * Aggregation used to aggregate all of this transition input values
+     *
+     * @see #getFuzzyInputValue()
+     * @see SNorm
+     * @see #inputs
+     */
+    @UsedInNetType(NetType.FPN)
+    public Aggregation inputAggregation = SNorm.MIN_S_NORM;
+
+    /**
+     * T-Norm used to calculate output value of this transition
+     *
+     * @see #getFuzzyOutputValue()
+     */
+    @UsedInNetType(NetType.FPN)
+    public TNorm internalTNorm = TNorm.MAX_T_NORM;
+
+    /**
+     * S-Norm used to store new value in this transition output places
+     *
+     * @see SNorm
+     * @see #outputs
+     */
+    @UsedInNetType(NetType.FPN)
+    public SNorm outputSNorm = SNorm.MIN_S_NORM;
+
+    /**
+     * Threshold which determines if this transition can be fired
+     *
+     * @see Net#getTransitionsThatCanBeActivated()
+     */
+    @UsedInNetType(NetType.FPN)
+    public Double inputTreshold = 0d;
+
+
+    /**
+     * Function used to sum current place value with arc input
+     */
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    private IntBinaryOperator adder = (left, right) -> left + right;
+
+    /**
+     * Function used to remove tokens from place with arc
+     */
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    private IntBinaryOperator subtractor = (left, right) -> left - right;
+
+
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    public IntBinaryOperator getSubtractor() {
+        return subtractor;
+    }
+
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    public void setSubtractor(IntBinaryOperator subtractor) {
+        this.subtractor = subtractor;
+    }
+
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    public IntBinaryOperator getAdder() {
+        return adder;
+    }
+
+    @UsedInNetGroup(NetGroup.CLASSICAL)
+    public void setAdder(IntBinaryOperator adder) {
+        this.adder = adder;
     }
 
     public BooleanProperty readyProperty() {

--- a/src/main/java/pl/edu/ur/pnes/petriNet/events/NetEvent.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/events/NetEvent.java
@@ -12,6 +12,8 @@ public abstract class NetEvent extends Event {
 
     public static EventType<NodesMovedEvent> NODES_MOVED = new EventType<>(ANY, "NET_ANY");
 
+    public static EventType<NetTypeChangedEvent> TYPE_CHANGED = new EventType<>(ANY, "NET_TYPE_CHANGED");
+
 
     public NetEvent(EventType<? extends NetEvent> eventType) {
         super(eventType);

--- a/src/main/java/pl/edu/ur/pnes/petriNet/events/NetTypeChangedEvent.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/events/NetTypeChangedEvent.java
@@ -1,0 +1,37 @@
+package pl.edu.ur.pnes.petriNet.events;
+
+import pl.edu.ur.pnes.petriNet.NetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.NetType;
+
+/**
+ * Event dispatched when net type changes
+ */
+public class NetTypeChangedEvent extends NetEvent {
+
+    private final NetGroup newGroup;
+
+    /**
+     * New net type group
+     * same as {@link NetType#netGroup}
+     * @return new group value
+     */
+    public NetGroup getNewGroup() {
+        return newGroup;
+    }
+
+    /**
+     * New net type
+     * @return new net type
+     */
+    public NetType getNewType() {
+        return newType;
+    }
+
+    private final NetType newType;
+
+    public NetTypeChangedEvent(NetType newType, NetGroup newGroup) {
+        super(TYPE_CHANGED);
+        this.newType = newType;
+        this.newGroup = newGroup;
+    }
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetType.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetType.java
@@ -1,0 +1,76 @@
+package pl.edu.ur.pnes.petriNet.netTypes;
+
+import pl.edu.ur.pnes.petriNet.NetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetType;
+
+import java.util.function.Predicate;
+
+/**
+ * Describes a net type. Has information about its group, name, description, tokens property type, tokens validator
+ * Can be used with {@link pl.edu.ur.pnes.petriNet.netTypes.annotations.NotInNetType} and {@link UsedInNetType} to conditionally enable and disable fields
+ *
+ * @see NetGroup
+ * @see UsedInNetType
+ * @see pl.edu.ur.pnes.petriNet.netTypes.annotations.NotInNetType
+ */
+public enum NetType {
+    /**
+     * Most classical Petri net
+     */
+    PN(
+            "Perti Net",
+            NetGroup.CLASSICAL,
+            "A regular Petri net with integer tokens",
+            Integer.class,
+            integer -> integer >= 0
+    ),
+    /**
+     * Fuzzy Petri Net
+     */
+    FPN(
+            "Fuzzy Perti Net",
+            NetGroup.NON_CLASSICAL,
+            "A fuzzy Petri net with double token values in range [0-1]",
+            Double.class,
+            aDouble -> aDouble >= 0 && aDouble <= 1
+    );
+
+
+    /**
+     * Group of this net
+     */
+    public NetGroup netGroup;
+    /**
+     * Name to be displayed in UI
+     */
+    public String longName;
+    /**
+     * Hint for this net type (in the UI)
+     */
+    public String hint;
+    /**
+     * Type of tokens property used in this net
+     */
+    public Class<?> tokensType;
+    /**
+     * Validator that can be used to validate user input in properties panel
+     */
+    public Predicate<?> tokensValueValidator;
+
+    /**
+     *
+     * @param longName Name to be displayed in UI
+     * @param netGroup Group of this net
+     * @param hint Hint for this net type (in the UI)
+     * @param tokensType Type of tokens property used in this net
+     * @param tokensValueValidator Validator that can be used to validate user input in properties panel
+     * @param <T> tokens type
+     */
+    <T> NetType(String longName, NetGroup netGroup, String hint, Class<T> tokensType, Predicate<T> tokensValueValidator) {
+        this.netGroup = netGroup;
+        this.longName = longName;
+        this.hint = hint;
+        this.tokensType = tokensType;
+        this.tokensValueValidator = tokensValueValidator;
+    }
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetGroup.java
@@ -1,0 +1,21 @@
+package pl.edu.ur.pnes.petriNet.netTypes.annotations;
+
+import pl.edu.ur.pnes.petriNet.NetGroup;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks annotated element as not to be used with given {@link NetGroup}
+ *
+ * Has HIGHER priority than {@link UsedInNetGroup}
+ * Has LOWER priority than {@link UsedInNetType}
+ * Has LOWER priority than {@link NotInNetType}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR})
+public @interface NotInNetGroup {
+    NetGroup[] value();
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetType.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetType.java
@@ -1,0 +1,21 @@
+package pl.edu.ur.pnes.petriNet.netTypes.annotations;
+
+import pl.edu.ur.pnes.petriNet.netTypes.NetType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks annotated element as not to be used with given {@link NetType}
+ *
+ * Has HIGHER priority than {@link UsedInNetGroup}
+ * Has HIGHER priority than {@link UsedInNetType}
+ * Has HIGHER priority than {@link NotInNetGroup}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR})
+public @interface NotInNetType {
+    NetType[] value();
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetGroup.java
@@ -1,0 +1,22 @@
+package pl.edu.ur.pnes.petriNet.netTypes.annotations;
+
+import pl.edu.ur.pnes.petriNet.NetGroup;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Marks annotated element to be used with given {@link NetGroup}
+ * <p>
+ * Has LOWER priority than {@link NotInNetGroup}
+ * Has LOWER priority than {@link UsedInNetType}
+ * Has LOWER priority than {@link NotInNetType}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR})
+public @interface UsedInNetGroup {
+    NetGroup[] value();
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetType.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetType.java
@@ -1,0 +1,21 @@
+package pl.edu.ur.pnes.petriNet.netTypes.annotations;
+
+import pl.edu.ur.pnes.petriNet.netTypes.NetType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks annotated element to be used with given {@link NetType}
+ * <p>
+ * Has HIGHER priority than {@link UsedInNetGroup}
+ * Has LOWER priority than {@link NotInNetType}
+ * Has HIGHER priority than {@link NotInNetGroup}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR})
+public @interface UsedInNetType {
+    NetType[] value();
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/Aggregation.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/Aggregation.java
@@ -1,0 +1,15 @@
+package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
+
+import static java.lang.Double.NaN;
+
+/**
+ * Any SNorm or TNorm
+ *
+ * @see pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.SNorm
+ * @see pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.TNorm
+ * @see <a href="https://en.wikipedia.org/wiki/Fuzzy_set_operations#Aggregation_operations">https://en.wikipedia.org/wiki/Fuzzy_set_operations#Aggregation_operations</a></a>
+ */
+public interface Aggregation extends SNorm, TNorm {
+    double IDENTITY_ELEMENT = NaN;
+
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MaxTNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MaxTNorm.java
@@ -1,0 +1,8 @@
+package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
+
+class MaxTNorm implements Aggregation {
+    @Override
+    public double applyAsDouble(double left, double right) {
+        return Math.max(left, right);
+    }
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MinSNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MinSNorm.java
@@ -1,0 +1,8 @@
+package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
+
+class MinSNorm implements Aggregation {
+    @Override
+    public double applyAsDouble(double left, double right) {
+        return Math.min(left, right);
+    }
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/SNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/SNorm.java
@@ -1,0 +1,20 @@
+package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
+
+import java.util.function.DoubleBinaryOperator;
+
+/**
+ * Represents S-Norm (T-conorm)
+ *
+ * @see Aggregation
+ * @see <a href="https://en.wikipedia.org/wiki/T-norm#T-conorms">https://en.wikipedia.org/wiki/T-norm#T-conorms</a>
+ */
+public interface SNorm extends DoubleBinaryOperator {
+    /**
+     * IDENTITY ELEMENT for all S-Norms
+     */
+    double IDENTITY_ELEMENT = 0;
+
+    Aggregation MIN_S_NORM = new MinSNorm();
+
+
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/TNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/TNorm.java
@@ -1,0 +1,19 @@
+package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
+
+import java.util.function.DoubleBinaryOperator;
+
+
+/**
+ * Represents T-Norm
+ *
+ * @see Aggregation
+ * @see <a href="https://en.wikipedia.org/wiki/T-norm#Definition">https://en.wikipedia.org/wiki/T-norm#Definition</a>
+ */
+public interface TNorm extends DoubleBinaryOperator {
+    /**
+     * IDENTITY ELEMENT for all T-norms
+     */
+    double IDENTITY_ELEMENT = 1;
+
+    Aggregation MAX_T_NORM = new MaxTNorm();
+}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/NetSnapshot.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/NetSnapshot.java
@@ -15,7 +15,7 @@ import java.util.Map;
  */
 public class NetSnapshot {
     private Integer netHashCode = null;
-    private final Map<String, Double> tokens = new HashMap<>();
+    private final Map<String, Object> tokens = new HashMap<>();
 
     private static final Logger logger = LogManager.getLogger(NetSnapshot.class);
 
@@ -34,6 +34,7 @@ public class NetSnapshot {
     /**
      * Restores this snapshot to the given net.
      * If the hash of given net is not equal to when the snapshot was created, throws.
+     *
      * @param net Where to restore the snapshot to.
      * @throws IllegalStateException if Net hash changed or any Node cannot be found
      */

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/Rules.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/Rules.java
@@ -8,7 +8,7 @@ import java.util.function.Predicate;
 public enum Rules {
     R1(transition ->
             transition.inputs.entrySet().stream().allMatch(
-                    placeArcEntry -> placeArcEntry.getKey().getTokens() >= placeArcEntry.getValue().getWeight()
+                    placeArcEntry -> placeArcEntry.getKey().getTokensAs(Integer.class) >= placeArcEntry.getValue().getWeight()
             )
     ),
     R2(transition -> {

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/SimulatorFacade.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/SimulatorFacade.java
@@ -242,11 +242,17 @@ public class SimulatorFacade {
     }
 
     public void singleManualStep(Transition transitionToBeActivated) {
+
+        // If it is not paused nor stopped, then do nothing
+        if (!getAutoStepState().equals(AutoStepState.PAUSED) && !getAutoStepState().equals(AutoStepState.STOPPED))
+            return;
+
         logger.info("manual step fired on transition {}", transitionToBeActivated.getName());
         try {
             simulator.fireTransition(transitionToBeActivated);
+            setAutoStepState(AutoStepState.PAUSED);
         } catch (TransitionCannotBeActivatedException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage());
         }
         simulator.calculateTransitionsThatCanBeActivated();
     }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/Mode.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/Mode.java
@@ -1,9 +1,0 @@
-//package pl.edu.ur.pnes.petriNet.visualizer;
-//
-//public enum Mode {
-//    NONE,
-//    ADD_TOKENS,
-//    REMOVE_TOKENS,
-//    EDIT,
-//    RUN;
-//}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/NetSelectionModel.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/NetSelectionModel.java
@@ -1,6 +1,0 @@
-package pl.edu.ur.pnes.petriNet.visualizer;
-
-import javafx.scene.control.SelectionModel;
-
-//public class NetSelectionModel extends SelectionModel<String> {
-//}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/Visualization.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/Visualization.java
@@ -1,8 +1,0 @@
-package pl.edu.ur.pnes.petriNet.visualizer;
-
-public class Visualization {
-    VisualizationShape shape;
-    String label;
-
-
-}

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizationShape.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizationShape.java
@@ -1,6 +1,0 @@
-package pl.edu.ur.pnes.petriNet.visualizer;
-
-public enum VisualizationShape {
-    CIRCLE,
-    RECT
-}

--- a/src/main/java/pl/edu/ur/pnes/utils/SoundAlertUtils.java
+++ b/src/main/java/pl/edu/ur/pnes/utils/SoundAlertUtils.java
@@ -4,9 +4,12 @@ import java.awt.*;
 
 public class SoundAlertUtils {
     public static void playWarning() {
-        final Runnable runnable = (Runnable) Toolkit.getDefaultToolkit().getDesktopProperty("win.sound.default");
-        if (runnable != null) {
-            runnable.run();
-        }
+//        final Runnable runnable = (Runnable) Toolkit.getDefaultToolkit().getDesktopProperty("win.sound.default");
+//        if (runnable != null) {
+//            runnable.run();
+//        }
+
+        // this works on GNU/Linux, if it does not work on Windows, then restore above code and add platform check
+        Toolkit.getDefaultToolkit().beep();
     }
 }


### PR DESCRIPTION
Added NetType and NetGroup, where all possible net Types will be added

Created UsedInNetGroup, UsedInNetType, NotInNetGroup, NotInNetType
those are annotations that can be added to fields/methods/classes and provide information if certain element can be used with given NetType/NetGroup. Can be used in PropertiesPanel.

Added Aggregation, SNorm, TNorm
those are interfaces describing known fuzzy logic [T-norms](https://en.wikipedia.org/wiki/T-norm) and [S-norms (T-conorms)](https://en.wikipedia.org/wiki/T-norm#T-conorms)

package-private classes MinSNorm and MaxTNorm implement those interfaces. They can be accessed from SNorm and TNorm (and Aggregation) interfaces static fields. They shall not be instantiated again not to use unnecessary memory.

Net has new properties:
Net.removeInputsOnTransitionFire - rule describing input handling (keep/reset) in fuzzy nets.
Net.netTypeProperty - property containing current NetType for that net.

When in RUN mode, and in PAUSED or STOPPED state, transition can now be clicked to fire it manually.

Other:

Fixed SoundAlertUtils not working on GNU/Linux
Added focussedSession property to MainController, can be used in the future