### PR TITLE
Code cleanup, optimizations

### DIFF
--- a/src/main/java/pl/edu/ur/pnes/MainApp.java
+++ b/src/main/java/pl/edu/ur/pnes/MainApp.java
@@ -8,7 +8,10 @@ import javafx.stage.Stage;
 import jfxtras.styles.jmetro.JMetro;
 import jfxtras.styles.jmetro.Style;
 import pl.edu.ur.pnes.editor.Session;
-import pl.edu.ur.pnes.petriNet.*;
+import pl.edu.ur.pnes.petriNet.Arc;
+import pl.edu.ur.pnes.petriNet.PetriNet;
+import pl.edu.ur.pnes.petriNet.Place;
+import pl.edu.ur.pnes.petriNet.Transition;
 import pl.edu.ur.pnes.petriNet.netTypes.NetType;
 
 import java.io.IOException;
@@ -41,8 +44,8 @@ public class MainApp extends Application {
 
         // Initial for testing
         final var net = new PetriNet();
-        net.setNetType(NetType.PN);
         {
+            net.setNetType(NetType.PN);
             final Place place1 = new Place(net);
             final Place place2 = new Place(net);
             final Place place3 = new Place(net);

--- a/src/main/java/pl/edu/ur/pnes/editor/Session.java
+++ b/src/main/java/pl/edu/ur/pnes/editor/Session.java
@@ -2,6 +2,7 @@ package pl.edu.ur.pnes.editor;
 
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.*;
+import javafx.scene.control.Tab;
 import pl.edu.ur.pnes.editor.history.UndoHistory;
 import pl.edu.ur.pnes.petriNet.Net;
 import pl.edu.ur.pnes.petriNet.PetriNet;
@@ -19,6 +20,7 @@ public class Session {
     ////////////////////////////////////////////////////////////////////////////////
 
     ObjectProperty<Mode> modeProperty = new SimpleObjectProperty<>(Mode.EDIT);
+    private Tab uiTab;
 
     public ObjectProperty<Mode> mode() {
         return modeProperty;
@@ -110,6 +112,20 @@ public class Session {
             throw new IllegalStateException("Unnamed session needs to be 'saved as'.");
         }
         // TODO: saving
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    public void close() {
+        // TODO: close session
+    }
+
+    public Tab getUiTab() {
+        return uiTab;
+    }
+
+    public void setUiTab(Tab uiTab) {
+        this.uiTab = uiTab;
     }
 
     // TODO: load (from static function/factory)

--- a/src/main/java/pl/edu/ur/pnes/petriNet/Net.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/Net.java
@@ -228,7 +228,12 @@ public abstract class Net {
                     .filter(t -> activationRule.test(t));
 
             case FPN -> getTransitions().stream()
-                    .filter(t -> t.getFuzzyInputValue() >= t.inputTreshold);
+                    .filter(t ->
+                            // there is at least one input with tokens > 0
+                            t.inputs.entrySet().stream().anyMatch(placeArcEntry -> placeArcEntry.getKey().getTokensAs(Double.class) > 0.000001)
+                                    // and input condition is satisfied
+                                    && t.getFuzzyInputValue() >= t.inputTreshold
+                    );
 
             //noinspection UnnecessaryDefault
             default -> throw new IllegalStateException("Unhandled net type");

--- a/src/main/java/pl/edu/ur/pnes/petriNet/Transition.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/Transition.java
@@ -2,6 +2,7 @@ package pl.edu.ur.pnes.petriNet;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import pl.edu.ur.pnes.petriNet.netTypes.NetGroup;
 import pl.edu.ur.pnes.petriNet.netTypes.NetType;
 import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetGroup;
 import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetType;

--- a/src/main/java/pl/edu/ur/pnes/petriNet/events/NetTypeChangedEvent.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/events/NetTypeChangedEvent.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.events;
 
-import pl.edu.ur.pnes.petriNet.NetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.NetGroup;
 import pl.edu.ur.pnes.petriNet.netTypes.NetType;
 
 /**

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetGroup.java
@@ -1,9 +1,9 @@
-package pl.edu.ur.pnes.petriNet;
+package pl.edu.ur.pnes.petriNet.netTypes;
 
 import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetGroup;
 
 /**
- * Grous multiple {@link pl.edu.ur.pnes.petriNet.netTypes.NetType}s
+ * Groups multiple {@link pl.edu.ur.pnes.petriNet.netTypes.NetType}s
  * Allow for conditional enabling/disabling of fields when used with {@link UsedInNetGroup} and {@link pl.edu.ur.pnes.petriNet.netTypes.annotations.NotInNetGroup}
  *
  * @see pl.edu.ur.pnes.petriNet.netTypes.NetType

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetType.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/NetType.java
@@ -1,6 +1,5 @@
 package pl.edu.ur.pnes.petriNet.netTypes;
 
-import pl.edu.ur.pnes.petriNet.NetGroup;
 import pl.edu.ur.pnes.petriNet.netTypes.annotations.UsedInNetType;
 
 import java.util.function.Predicate;

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/NotInNetGroup.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.netTypes.annotations;
 
-import pl.edu.ur.pnes.petriNet.NetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.NetGroup;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetGroup.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/annotations/UsedInNetGroup.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.netTypes.annotations;
 
-import pl.edu.ur.pnes.petriNet.NetGroup;
+import pl.edu.ur.pnes.petriNet.netTypes.NetGroup;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/Aggregation.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/Aggregation.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
 
-import static java.lang.Double.NaN;
+import java.util.function.DoubleBinaryOperator;
 
 /**
  * Any SNorm or TNorm
@@ -9,7 +9,5 @@ import static java.lang.Double.NaN;
  * @see pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN.TNorm
  * @see <a href="https://en.wikipedia.org/wiki/Fuzzy_set_operations#Aggregation_operations">https://en.wikipedia.org/wiki/Fuzzy_set_operations#Aggregation_operations</a></a>
  */
-public interface Aggregation extends SNorm, TNorm {
-    double IDENTITY_ELEMENT = NaN;
-
+public abstract class Aggregation implements DoubleBinaryOperator {
 }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MaxTNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MaxTNorm.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
 
-class MaxTNorm implements Aggregation {
+class MaxTNorm extends TNorm {
     @Override
     public double applyAsDouble(double left, double right) {
         return Math.max(left, right);

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MinSNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/MinSNorm.java
@@ -1,6 +1,6 @@
 package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
 
-class MinSNorm implements Aggregation {
+class MinSNorm extends SNorm {
     @Override
     public double applyAsDouble(double left, double right) {
         return Math.min(left, right);

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/SNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/SNorm.java
@@ -1,20 +1,16 @@
 package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
 
-import java.util.function.DoubleBinaryOperator;
-
 /**
  * Represents S-Norm (T-conorm)
  *
  * @see Aggregation
  * @see <a href="https://en.wikipedia.org/wiki/T-norm#T-conorms">https://en.wikipedia.org/wiki/T-norm#T-conorms</a>
  */
-public interface SNorm extends DoubleBinaryOperator {
+public abstract class SNorm extends Aggregation {
     /**
      * IDENTITY ELEMENT for all S-Norms
      */
-    double IDENTITY_ELEMENT = 0;
+    public static final double IDENTITY_ELEMENT = 0;
 
-    Aggregation MIN_S_NORM = new MinSNorm();
-
-
+    public static final SNorm MIN_S_NORM = new MinSNorm();
 }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/TNorm.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/netTypes/nonClassical/FPN/TNorm.java
@@ -1,19 +1,16 @@
 package pl.edu.ur.pnes.petriNet.netTypes.nonClassical.FPN;
 
-import java.util.function.DoubleBinaryOperator;
-
-
 /**
  * Represents T-Norm
  *
  * @see Aggregation
  * @see <a href="https://en.wikipedia.org/wiki/T-norm#Definition">https://en.wikipedia.org/wiki/T-norm#Definition</a>
  */
-public interface TNorm extends DoubleBinaryOperator {
+public abstract class TNorm extends Aggregation {
     /**
      * IDENTITY ELEMENT for all T-norms
      */
-    double IDENTITY_ELEMENT = 1;
+    public static final double IDENTITY_ELEMENT = 1;
 
-    Aggregation MAX_T_NORM = new MaxTNorm();
+    public static final TNorm MAX_T_NORM = new MaxTNorm();
 }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/NetSnapshot.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/NetSnapshot.java
@@ -16,6 +16,7 @@ import java.util.Map;
 public class NetSnapshot {
     private Integer netHashCode = null;
     private final Map<String, Object> tokens = new HashMap<>();
+    private boolean alreadyRestored = false;
 
     private static final Logger logger = LogManager.getLogger(NetSnapshot.class);
 
@@ -58,5 +59,11 @@ public class NetSnapshot {
             )
                     .setTokens(tokensCount);
         });
+
+        alreadyRestored = true;
+    }
+
+    public boolean isAlreadyRestored() {
+        return alreadyRestored;
     }
 }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/Simulator.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/Simulator.java
@@ -79,9 +79,21 @@ class Simulator {
 
 
     void automaticStep() {
+        try {
+            automaticStep(false);
+        } catch (TransitionCannotBeActivatedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void automaticStep(boolean throwIfCannotActivate) throws TransitionCannotBeActivatedException {
         this.logger.info("automatic step fired");
 
-        if (this.checkIfDone()) return;
+        if (this.checkIfDone()) {
+            if (throwIfCannotActivate)
+                throw new TransitionCannotBeActivatedException();
+            return;
+        }
 
         this.logger.debug("Can activate {} transitions", this.transitionsThatCanBeActivated.size());
 

--- a/src/main/java/pl/edu/ur/pnes/petriNet/simulator/SimulatorFactory.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/simulator/SimulatorFactory.java
@@ -1,9 +1,10 @@
 package pl.edu.ur.pnes.petriNet.simulator;
 
+import pl.edu.ur.pnes.editor.Session;
 import pl.edu.ur.pnes.petriNet.Net;
 
 public class SimulatorFactory {
-    public static SimulatorFacade create(Net net) {
-        return new SimulatorFacade(new Simulator(net));
+    public static SimulatorFacade create(Session session) {
+        return new SimulatorFacade(new Simulator(session.net), session);
     }
 }

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizerFacade.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizerFacade.java
@@ -9,6 +9,7 @@ import javafx.geometry.Point3D;
 import javafx.scene.input.MouseEvent;
 import org.graphstream.ui.graphicGraph.GraphicElement;
 import org.graphstream.ui.view.util.InteractiveElement;
+import pl.edu.ur.pnes.editor.Session;
 import pl.edu.ur.pnes.petriNet.Net;
 import pl.edu.ur.pnes.petriNet.NetElement;
 import pl.edu.ur.pnes.petriNet.Node;
@@ -20,9 +21,11 @@ import java.util.Optional;
 
 public class VisualizerFacade {
     final Visualizer visualizer;
+    private final Session session;
     private Net net;
 
-    VisualizerFacade(Visualizer visualizer) {
+    VisualizerFacade(Visualizer visualizer, Session session) {
+        this.session = session;
         this.visualizer = visualizer;
     }
 

--- a/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizerFactory.java
+++ b/src/main/java/pl/edu/ur/pnes/petriNet/visualizer/VisualizerFactory.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.scene.layout.Pane;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import pl.edu.ur.pnes.editor.Session;
 
 import java.net.URL;
 import java.util.Objects;
@@ -11,9 +12,9 @@ import java.util.Objects;
 public class VisualizerFactory {
     private final Logger logger = LogManager.getLogger(VisualizerFactory.class);
 
-    public VisualizerFacade create(Pane parentNode, String cssResourceName) {
+    public VisualizerFacade create(Pane parentNode, String cssResourceName, Session session) {
 
-        var facade = new VisualizerFacade(new Visualizer());
+        var facade = new VisualizerFacade(new Visualizer(), session);
         Platform.runLater(() -> {
             Pane element =facade.visualizer.getElement();
             parentNode.getChildren().add(element);

--- a/src/main/java/pl/edu/ur/pnes/ui/controls/Icon.java
+++ b/src/main/java/pl/edu/ur/pnes/ui/controls/Icon.java
@@ -1,24 +1,22 @@
 package pl.edu.ur.pnes.ui.controls;
 
 
-import java.io.IOException;
-
-import javafx.beans.property.StringProperty;
-import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
-import javafx.scene.layout.VBox;
-import javafx.scene.text.Font;
 import pl.edu.ur.pnes.MainApp;
 
 public class Icon extends Label {
 
     public Icon() {
+        this("");
+    }
+
+    public Icon(String iconText) {
         super();
         FXMLLoader fxmlLoader = new FXMLLoader(MainApp.class.getResource("ui/controls/Icon.fxml"));
         fxmlLoader.setRoot(this);
 //        this.setFont(new Font("pnesfont", 20));
+        this.setText(iconText);
     }
 
 }

--- a/src/main/resources/pl/edu/ur/pnes/ui/panels/center-panel.fxml
+++ b/src/main/resources/pl/edu/ur/pnes/ui/panels/center-panel.fxml
@@ -1,27 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.layout.VBox?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 
-<VBox fx:id="root" prefHeight="200.0" prefWidth="178.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="root" prefHeight="200.0" prefWidth="178.0" xmlns="http://javafx.com/javafx/11.0.2" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <HBox fx:id="centerToolbar" spacing="5.0">
+        <HBox fx:id="primaryToolbar" spacing="5.0">
             <children>
-                <HBox fx:id="centerToolbarLeft" spacing="5.0">
+                <HBox fx:id="primaryToolbarLeft" spacing="5.0">
                     <children>
-                        <Button mnemonicParsing="false" text="Button" />
                     </children>
                 </HBox>
                 <Pane prefHeight="1.0" prefWidth="100.0" HBox.hgrow="ALWAYS" />
-                <HBox fx:id="centerToolbarRight" spacing="5.0" />
+                <HBox fx:id="primaryToolbarRight" spacing="5.0" />
             </children>
             <padding>
                 <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
             </padding>
         </HBox>
+      <HBox fx:id="secondaryToolbar" spacing="5.0">
+         <children>
+            <HBox fx:id="secondaryToolbarLeft" spacing="5.0">
+               <children>
+               </children>
+            </HBox>
+            <Pane prefHeight="1.0" prefWidth="100.0" HBox.hgrow="ALWAYS" />
+            <HBox fx:id="secondaryToolbarRight" spacing="5.0" />
+         </children>
+         <padding>
+            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+         </padding>
+      </HBox>
         <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS">
             <children>
                 <Pane fx:id="graphPane" HBox.hgrow="ALWAYS" />


### PR DESCRIPTION
Changes:
- Aggregation is superclass to TNorm and SNorm
- NetSnapshot has value NetSnapshot.alreadyRestored indicating if it was already restored
- thanks to previous, clicking Stop after snapshot has been restored exits RUN mode
- added CenterPanelController.secondaryToolbar located below primary
- fix: fuzzy transitions will not activate if all of its inputs all equal zero (less than epsilon)
- CenterPanelController.NET_GROUPS and CenterPanelController.NET_TYPES are now EnumSets
- CenterPanelController.NET_GROUPS contains only types that are populated with at least one NetType
- moved: pl.edu.ur.pnes.petriNet.NetGroup -> pl.edu.ur.pnes.petriNet.netTypes.NetGroup
- added overload to Simulator.automaticStep that throws if no Transition can be activated
- autoStepThread now does not check if net is done every 1/30 s, insteads it only checks before actual step
- Places and Transitions can be only created using LMB
- Session passed to VisualizerFacade and SimulatorFacade
- MainController.focusedSession gets focused session, but ONLY FROM CENTER PANEL
- Icon can be instantiated with initial text
- Session has reference to UI: Session.getUiTab
- Tab with editor has reference to session: (Session)Tab.getUserData()